### PR TITLE
fix ruby regexp engine going to infinite loop with specific string and regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,3 +235,4 @@ appear in the text.
         - text &rightarrow; `"cialis vs cialis spam guestbook.php?action=http://cialiswalmart.shop"`
     - **Output:** `3`
 
+

--- a/README.md
+++ b/README.md
@@ -235,4 +235,3 @@ appear in the text.
         - text &rightarrow; `"cialis vs cialis spam guestbook.php?action=http://cialiswalmart.shop"`
     - **Output:** `3`
 
-

--- a/lib/ramparts/parsers/phone_parser.rb
+++ b/lib/ramparts/parsers/phone_parser.rb
@@ -82,7 +82,7 @@ class PhoneParser
     Regexp.new(/(\()?(\d|#{BASE_MATCHING}){1}([^\w]*(\d|#{BASE_MATCHING}){1}[^\w]*){5,}(\d|#{BASE_MATCHING}){1}/)
 
   # The final regex used to match phone numbers for MR
-  MR_REGEX = Regexp.new(/(\-*\.?\d{1}\.?\-*){7,}/)
+  MR_REGEX = Regexp.new(/(\-*\.?\d{1}\.?\-?){7,}/)
 
   # Replacements used for phonetics for MR
   REPLACEMENTS = {
@@ -116,13 +116,8 @@ class PhoneParser
   # Parses the phone number for MR, uses a variety of options
   def parse_phone_number(text, options)
     text = text.delete(' ') if options.fetch(:remove_spaces, true)
-
     text = text.downcase.gsub(/#{REGEX_PHONETICS}/, REPLACEMENTS)
-
-    if options.fetch(:parse_leet, true)
-      text = text.gsub(/#{REGEX_LEET_SPEAK}/, LEET_REPLACEMENTS)
-    end
-
+    text = text.gsub(/#{REGEX_LEET_SPEAK}/, LEET_REPLACEMENTS) if options.fetch(:parse_leet, true)
     text.gsub(/[^\w]/, '-').gsub(/[a-z]/, '.')
   end
 

--- a/spec/data/phone_data/truthy_phone_data.rb
+++ b/spec/data/phone_data/truthy_phone_data.rb
@@ -12,6 +12,11 @@ PHONE_TRUTHY_WITH_ANSWERS_AND_SPACES = [
 
 PHONE_TRUTHY_WITH_ANSWERS = [
   {
+    matches: [],
+    text: 'Резюме и референс письма нет Во всех семьях я работаю по устной рекомендации знакомых В семье в которой Бен и Джорджик я уже 7 лет Мальчикам 9 и 6 лет Второго забирали вместе с папой из госпиталя Работала у них иногда и по 12 часов Они живут в 5 ти минутах ходьбы от меня Детки подросли И',
+    filtered:  "Резюме и референс письма нет Во всех семьях я работаю по устной рекомендации знакомых В семье в которой Бен и Джорджик я уже 7 лет Мальчикам 9 и 6 лет Второго забирали вместе с папой из госпиталя Работала у них иногда и по 12 часов Они живут в 5 ти минутах ходьбы от меня Детки подросли И"
+  },
+  {
     matches: ["5.5.5.4.3.8.4.8.3.8"],
     text: "I need a babysitter and errand for my son textme direct on my number if you are interested 5.5.5.4.3.8.4.8.3.8",
     filtered:  "I need a babysitter and errand for my son textme direct on my number if you are interested #{INSERTABLE}"


### PR DESCRIPTION
A COPY OF PREVIOUSLY CLOSED PR DUE TO TRAVIS DIDN'T REPORT THE STATUS.
[Asana](https://app.asana.com/0/816909066340457/687898250440210/f) Matching of the following string and regexp runs for a long time. This issue is specific for ruby regexp engine not for perl for example.
```
String: "------------------------------------------------------------------------------------------------------7------------9-6--------------------------------------------------------------12--------------5-----------------------------------"
```
```
Regexp: /(\-*\.?\d{1}\.?\-*){7,}/
```

